### PR TITLE
fix: use Trusted Publishing OIDC instead of NPM_TOKEN

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,5 +111,5 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
+          # No NPM_TOKEN needed - using Trusted Publishing (OIDC)


### PR DESCRIPTION
Remove NODE_AUTH_TOKEN to let npm use OIDC authentication via Trusted Publishing instead of token-based auth.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use npm Trusted Publishing (OIDC) for releases and remove NODE_AUTH_TOKEN from CI. No NPM token needed; provenance stays enabled.

<sup>Written for commit 904f7cff7312583f825e9d1c35231f3fe6f13e21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

