### PR TITLE
fix: restore NPM_TOKEN - semantic-release requires token auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,5 +111,5 @@ jobs:
         run: pnpm exec semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
-          # No NPM_TOKEN needed - using Trusted Publishing (OIDC)


### PR DESCRIPTION
@semantic-release/npm doesn't support OIDC Trusted Publishing. Need to use Granular Access Token with 2FA bypass enabled.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore npm token auth in CI for semantic-release; @semantic-release/npm doesn’t support OIDC Trusted Publishing. Sets NODE_AUTH_TOKEN from secrets.NPM_TOKEN so npm publish works again.

- **Migration**
  - Ensure the NPM_TOKEN GitHub secret is set to a Granular Access Token with 2FA bypass enabled.

<sup>Written for commit e99048180b9c847172d3517f5137984e468a2bdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

