### PR TITLE
add @prisma/generator-helper as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "url": "https://github.com/EddieRydell/prisma-safe-delete/issues"
   },
   "peerDependencies": {
+    "@prisma/generator-helper": ">=7.0.0",
     "prisma": ">=7.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add @prisma/generator-helper (>=7.0.0) as a peer dependency to align with Prisma v7 and prevent version mismatches during generator execution.

<sup>Written for commit 5877317ef56545a366753624601747032136b23f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

