### PR TITLE
docs: document squash merge and conventional commit requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,10 +94,19 @@ pnpm run test:coverage
 4. Update documentation if needed
 5. Submit a pull request
 
+### PR Title Convention
+
+This project uses [semantic-release](https://semantic-release.gitbook.io/) to automate versioning and publishing. The repo is configured for **squash merges only**, so your PR title becomes the commit message on `main`. PR titles must follow [Conventional Commits](https://www.conventionalcommits.org/) format:
+
+- `fix: description` — patch release (bug fixes)
+- `feat: description` — minor release (new features)
+- `feat!: description` or `BREAKING CHANGE:` in body — major release
+
+Commits during development can use any format — only the PR title matters.
+
 ### PR Guidelines
 
 - Keep changes focused and atomic
-- Write clear commit messages
 - Add tests for new functionality
 - Update the README if adding user-facing features
 


### PR DESCRIPTION
## Summary
- Added PR title convention section to CONTRIBUTING.md explaining the conventional commits requirement
- Documents that the repo uses squash-only merges, so only the PR title matters for release triggering
- Removed "write clear commit messages" guideline (no longer relevant with squash merges)

## Test plan
- [x] Verify CONTRIBUTING.md renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documented squash-only merges and the requirement to use Conventional Commits in PR titles so semantic-release can version and publish correctly. Removed the outdated “write clear commit messages” guideline since only the PR title is used.

<sup>Written for commit fa6ef01deb028f67d48eab628b1b749522cd30c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

